### PR TITLE
Add padding for small outputs

### DIFF
--- a/frontend/src/components/EventTable.vue
+++ b/frontend/src/components/EventTable.vue
@@ -10,7 +10,7 @@
     <template #item="{ item }">
         <tr>
         <td><span v-html="item.time.toISOString().split('T').join(' ').slice(0, -5)" /></td>
-        <td>
+        <td class="py-2">
             <v-chip label :color="color(item.priority)" class="mb-3 white--text" @click="$emit('update:search', item.priority)">
               <span v-html="highlightMatches(item.priority)" />
             </v-chip><br>


### PR DESCRIPTION
Signed-off-by: Frank Jogeleit <fj@move-elevator.de>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**What this PR does / why we need it**:

Add padding if the output of an event is small and the table cell has the minimal height.

<img width="632" alt="Bildschirmfoto 2021-06-24 um 10 35 47" src="https://user-images.githubusercontent.com/16627596/123230889-f8abd500-d4d7-11eb-9c77-89fd772e2706.png">
