### PR TITLE
chore(OWNERS): remove duplicates in reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,10 +2,5 @@ approvers:
   - Issif
   - cpanato
   - fjogeleit
-reviewers:
-  - Issif
-  - cpanato
-  - leogr
-  - fjogeleit
 emeritus_approvers:
   - leogr


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

For https://github.com/falcosecurity/falco/issues/2115, this removes duplicates in OWNERS for members that are both in the `reviewers` and in the `approvers` or `emeritus_approvers` section.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:


