### PR TITLE
fix the empty result when the value of an output field contains a dash/slash + trim prefix with the timestamp and priority for the output

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -62,6 +62,8 @@ func AddEvent(c echo.Context) error {
 
 	models.GetOutputs().Update(payload.Outputs)
 
+	payload.Event.Output = utils.TrimPrefix(payload.Event.Output)
+
 	if err := events.Add(&payload.Event); err != nil {
 		return err
 	}

--- a/internal/database/redis/index.go
+++ b/internal/database/redis/index.go
@@ -44,6 +44,7 @@ func CreateIndex(client *redisearch.Client) {
 		AddField(redisearch.NewTextField("hostname")).
 		AddField(redisearch.NewTextField("source")).
 		AddField(redisearch.NewTextField("tags")).
+		AddField(redisearch.NewTextField("outputfields")).
 		AddField(redisearch.NewNumericField("timestamp")).
 		AddField(redisearch.NewTextField("json"))
 

--- a/internal/database/redis/set.go
+++ b/internal/database/redis/set.go
@@ -30,6 +30,12 @@ func SetKey(client *redisearch.Client, event *models.Event) error {
 
 	jsonString, _ := json.Marshal(event)
 
+	of := make([]string, 0, len(event.OutputFields))
+
+	for _, i := range event.OutputFields {
+		of = append(of, fmt.Sprintf("%v", i))
+	}
+
 	doc := redisearch.NewDocument(fmt.Sprintf("event:%v", event.UUID), 1.0).
 		Set("rule", event.Rule).
 		Set("priority", event.Priority).
@@ -38,6 +44,7 @@ func SetKey(client *redisearch.Client, event *models.Event) error {
 		Set("timestamp", event.Time.UnixNano()/1e3).
 		Set("tags", utils.Escape(strings.Join(event.Tags, ","))).
 		Set("json", string(jsonString)).
+		Set("outputfields", utils.Escape(strings.Join(of, ","))).
 		Set("uuid", event.UUID).
 		SetTTL(c.TTL)
 	if event.Hostname != "" {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -29,6 +29,7 @@ import (
 const (
 	extractNumber = "^[0-9]+"
 	extractUnity  = "[a-z-A-Z]+$"
+	trimPrefix    = "(?i)^\\d{2}:\\d{2}:\\d{2}\\.\\d{9}\\:\\ (Debug|Info|Informational|Notice|Warning|Error|Critical|Alert|Emergency)"
 )
 
 const (
@@ -39,11 +40,12 @@ const (
 	fatalLog
 )
 
-var regExtractNumber, regExtractUnity *regexp.Regexp
+var regExtractNumber, regExtractUnity, regTrimPrefix *regexp.Regexp
 
 func init() {
 	regExtractNumber, _ = regexp.Compile(extractNumber)
 	regExtractUnity, _ = regexp.Compile(extractUnity)
+	regTrimPrefix, _ = regexp.Compile(trimPrefix)
 }
 
 func CheckErr(e error) {
@@ -164,9 +166,17 @@ func GetPriortiyInt(prio string) int {
 }
 
 func Escape(s string) string {
-	return strings.ReplaceAll(s, "-", `\-`)
+	s = strings.ReplaceAll(s, "-", `\-`)
+	s = strings.ReplaceAll(s, "/", "\\/")
+	return s
 }
 
 func UnEscape(s string) string {
-	return strings.ReplaceAll(s, `\-`, "-")
+	s = strings.ReplaceAll(s, `\-`, "-")
+	s = strings.ReplaceAll(s, `\\/`, "/")
+	return s
+}
+
+func TrimPrefix(s string) string {
+	return regTrimPrefix.ReplaceAllString(s, "")
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build


> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

An user noticed empty result when we search for an output field value with a / or -. It was fixed for the tags and hostnames not for other fields.

Moreover, I added a regexp to remove for the output field the timestamp + priority, it's a redundant info in the event board. It also so save some space.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

These changes will imply to flush all data, the schema in redisearch must be replaced.
