### PR TITLE
Rewrite redis client creation and add support for a redis username

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Events are stored in a `Redis` server with [`Redisearch`](https://github.com/Red
 #### Precedence: flag value -> environment variable value -> default value
 
 ```shell
-Usage of Falcosidekick-UI:  
+Usage of Falcosidekick-UI:
 -a string
       Listen Address (default "0.0.0.0", environment "FALCOSIDEKICK_UI_ADDR")
 -d boolean
       Disable authentication (environment "FALCOSIDEKICK_UI_DISABLEAUTH")
--l string   
+-l string
       Log level: "debug", "info", "warning", "error" (default "info",  environment "FALCOSIDEKICK_UI_LOGLEVEL")
 -p int
       Listen Port (default "2802", environment "FALCOSIDEKICK_UI_PORT")
@@ -33,14 +33,16 @@ Usage of Falcosidekick-UI:
 -t string
       TTL for keys, the format is X<unit>,
       with unit (s, m, h, d, W, M, y)" (default "0", environment "FALCOSIDEKICK_UI_TTL")
--u string  
+-u string
       User in format <login>:<password> (default "admin:admin", environment "FALCOSIDEKICK_UI_USER")
 -v boolean
       Display version
--w string  
+-w string
       Redis password (default "", environment "FALCOSIDEKICK_UI_REDIS_PASSWORD")
 -x boolean
       Allow CORS for development (environment "FALCOSIDEKICK_UI_DEV")
+-y string
+      Redis username (default "", environment "FALCOSIDEKICK_UI_REDIS_USERNAME")
 ```
 
 > If not user is set and the authentication is not disabled, the default user is `admin:admin`

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -19,6 +19,7 @@ type Configuration struct {
 	ListenAddress string `json:"listen-address"`
 	ListenPort    int    `json:"listen-port"`
 	RedisServer   string `json:"redis-server"`
+	RedisUsername string `json:"redis-username"`
 	RedisPassword string `json:"redis-password"`
 	DevMode       bool   `json:"dev-mode"`
 	DisableAuth   bool   `json:"disable-auth"`

--- a/internal/events/add.go
+++ b/internal/events/add.go
@@ -25,7 +25,11 @@ import (
 )
 
 func Add(e *models.Event) error {
-	client := redis.GetClient()
+	client, err := redis.GetClient()
+	if err != nil {
+		utils.WriteLog("error", err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
 	if err := redis.SetKey(client, e); err != nil {
 		utils.WriteLog("error", err.Error())
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/internal/events/count.go
+++ b/internal/events/count.go
@@ -24,7 +24,11 @@ import (
 )
 
 func Count(a *models.Arguments) (models.Results, error) {
-	c := redis.GetClient()
+	c, err := redis.GetClient()
+	if err != nil {
+		utils.WriteLog("error", err.Error())
+		return models.Results{}, echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
 	r, err := redis.CountKey(c, a)
 	if err != nil {
 		utils.WriteLog("error", err.Error())
@@ -34,7 +38,11 @@ func Count(a *models.Arguments) (models.Results, error) {
 }
 
 func CountBy(a *models.Arguments) (models.Results, error) {
-	c := redis.GetClient()
+	c, err := redis.GetClient()
+	if err != nil {
+		utils.WriteLog("error", err.Error())
+		return models.Results{}, echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
 	r, err := redis.CountKeyBy(c, a)
 	if err != nil {
 		utils.WriteLog("error", err.Error())

--- a/internal/events/search.go
+++ b/internal/events/search.go
@@ -15,13 +15,20 @@ limitations under the License.
 package events
 
 import (
+	"net/http"
+
 	"github.com/falcosecurity/falcosidekick-ui/internal/database/redis"
 	"github.com/falcosecurity/falcosidekick-ui/internal/models"
 	"github.com/falcosecurity/falcosidekick-ui/internal/utils"
+	echo "github.com/labstack/echo/v4"
 )
 
 func Search(a *models.Arguments) (models.Results, error) {
-	client := redis.GetClient()
+	client, err := redis.GetClient()
+	if err != nil {
+		utils.WriteLog("error", err.Error())
+		return models.Results{}, echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
 	results, err := redis.SearchKey(client, a)
 	if err != nil {
 		utils.WriteLog("error", err.Error())

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ type CustomValidator struct {
 func init() {
 	addr := utils.GetStringFlagOrEnvParam("a", "FALCOSIDEKICK_UI_ADDR", "0.0.0.0", "Listen Address")
 	redisserver := utils.GetStringFlagOrEnvParam("r", "FALCOSIDEKICK_UI_REDIS_URL", "localhost:6379", "Redis server address")
+	redisusername := utils.GetStringFlagOrEnvParam("y", "FALCOSIDEKICK_UI_REDIS_USERNAME", "", "Redis server username")
 	redispassword := utils.GetStringFlagOrEnvParam("w", "FALCOSIDEKICK_UI_REDIS_PASSWORD", "", "Redis server password")
 	port := utils.GetIntFlagOrEnvParam("p", "FALCOSIDEKICK_UI_PORT", 2802, "Listen Port")
 	ttl := utils.GetStringFlagOrEnvParam("t", "FALCOSIDEKICK_UI_TTL", "0s", "TTL for keys, the format is X<unit>, with unit (s, m, h, d, W, M, y)")
@@ -75,6 +76,8 @@ func init() {
       Redis password (default "", environment "FALCOSIDEKICK_UI_REDIS_PASSWORD")
 -x boolean
       Allow CORS for development (environment "FALCOSIDEKICK_UI_DEV")
+-y string
+      Redis username (default "", environment "FALCOSIDEKICK_UI_REDIS_USERNAME")
 `
 		fmt.Println(help)
 	}
@@ -99,6 +102,7 @@ func init() {
 	config.ListenAddress = *addr
 	config.ListenPort = *port
 	config.RedisServer = *redisserver
+	config.RedisUsername = *redisusername
 	config.RedisPassword = *redispassword
 	config.DevMode = *dev
 	config.TTL = utils.ConvertToSeconds(*ttl)
@@ -110,8 +114,8 @@ func init() {
 		config.LogLevel = "info"
 	}
 
-	redis.CreateClient()
-	redis.CreateIndex(redis.GetClient())
+	client := redis.CreateClient()
+	redis.CreateIndex(client)
 	models.CreateOutputs()
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind design
/kind documentation
/kind feature

**What this PR does / why we need it**:
Some systems administrators configure redis with ACLs which require a specific username to connect to an instance/pool. By default falcosidekick-ui wouldn't allow me to pass a username, now it does. Additionally I rewrote the redis client creation function to be more streamlined.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Related to https://github.com/falcosecurity/falcosidekick/pull/1212

